### PR TITLE
Update installation instructions for latest Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ $ brew tap hmarr/tap
 $ brew install codeowners
 ```
 
-Install the library with `go get`.
+Install the library with `go install`.
 
 ```console
-$ go get github.com/hmarr/codeowners@latest
+$ go install github.com/hmarr/codeowners/cmd/codeowners@latest
 ```
 
 ## Command line usage


### PR DESCRIPTION
`go install` is now required when not running from within a module, and the subcommand path is required as the root is not a `main` package.