### PR TITLE
Faster multi-file matching

### DIFF
--- a/cmd/codeowners/main.go
+++ b/cmd/codeowners/main.go
@@ -98,7 +98,7 @@ func printFileOwners(out io.Writer, ruleset codeowners.Ruleset, path string, own
 	}
 
 	// Figure out which of the owners we need to show according to the --owner filters
-	owners := []string{}
+	ownersToShow := make([]string, 0, len(rule.Owners))
 	for _, o := range rule.Owners {
 		// If there are no filters, show all owners
 		filterMatch := len(ownerFilters) == 0 && !showUnowned
@@ -108,12 +108,12 @@ func printFileOwners(out io.Writer, ruleset codeowners.Ruleset, path string, own
 			}
 		}
 		if filterMatch {
-			owners = append(owners, o.String())
+			ownersToShow = append(ownersToShow, o.String())
 		}
 	}
 
 	// If the owners slice is empty, no owners matched the filters so don't show anything
-	if len(owners) > 0 {
+	if len(ownersToShow) > 0 {
 		fmt.Fprintf(out, "%-70s  %s\n", path, strings.Join(ownersToShow, " "))
 	}
 	return nil

--- a/cmd/codeowners/main.go
+++ b/cmd/codeowners/main.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/hmarr/codeowners"
-	"github.com/karrick/godirwalk"
 	flag "github.com/spf13/pflag"
 )
 
@@ -60,19 +59,16 @@ func main() {
 			continue
 		}
 
-		err = godirwalk.Walk(startPath, &godirwalk.Options{
-			Callback: func(path string, dirent *godirwalk.Dirent) error {
-				if path == ".git" {
-					return filepath.SkipDir
-				}
+		err = filepath.WalkDir(startPath, func(path string, d os.DirEntry, err error) error {
+			if path == ".git" {
+				return filepath.SkipDir
+			}
 
-				// Only show code owners for files, not directories
-				if !dirent.IsDir() {
-					return printFileOwners(ruleset, path, ownerFilters, showUnowned)
-				}
-				return nil
-			},
-			Unsorted: true,
+			// Only show code owners for files, not directories
+			if !d.IsDir() {
+				return printFileOwners(ruleset, path, ownerFilters, showUnowned)
+			}
+			return nil
 		})
 
 		if err != nil {

--- a/codeowners.go
+++ b/codeowners.go
@@ -104,10 +104,10 @@ type Ruleset []Rule
 // last matching rule takes precedence.
 func (r Ruleset) Match(path string) (*Rule, error) {
 	for i := len(r) - 1; i >= 0; i-- {
-		rule := r[i]
+		rule := &r[i]
 		match, err := rule.Match(path)
 		if match || err != nil {
-			return &rule, err
+			return rule, err
 		}
 	}
 	return nil, nil

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/hmarr/codeowners
 go 1.14
 
 require (
-	github.com/karrick/godirwalk v1.17.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/karrick/godirwalk v1.17.0 h1:b4kY7nqDdioR/6qnbHQyDvmA17u5G1cZ6J+CZXwSWoI=
-github.com/karrick/godirwalk v1.17.0/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=


### PR DESCRIPTION
Most of the improvement comes from skipping a couple of unnecessary heap allocations.

Most notably, each matched `Rule` was being copied out of the `Ruleset` slice, then returned as a reference, which meant it was being caught by escape analysis and getting promoted to the heap (causing an allocation). By taking the reference to the slice element and returning that we avoid the extra allocation. That change seems have a remarkably large impact when matching lots of files.

```
components $ hyperfine ./codeowners ./codeowners-new
Benchmark 1: ./codeowners
  Time (mean ± σ):      3.394 s ±  0.011 s    [User: 5.398 s, System: 0.232 s]
  Range (min … max):    3.374 s …  3.415 s    10 runs

Benchmark 2: ./codeowners-new
  Time (mean ± σ):      1.781 s ±  0.009 s    [User: 1.778 s, System: 0.022 s]
  Range (min … max):    1.776 s …  1.807 s    10 runs

Summary
  './codeowners-new' ran
    1.91 ± 0.01 times faster than './codeowners'
```

This branch also removes an unnecssary dependency (godirwalk), as stdlib directory walking is equally fast now.