### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,11 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:

--- a/match.go
+++ b/match.go
@@ -17,7 +17,7 @@ type pattern struct {
 func newPattern(patternStr string) (pattern, error) {
 	pat := pattern{pattern: patternStr}
 
-	if !strings.ContainsAny(patternStr, "*?\\") && patternStr[0] == os.PathSeparator {
+	if !strings.ContainsAny(patternStr, "*?\\") && patternStr[0] == '/' {
 		pat.leftAnchoredLiteral = true
 	} else {
 		patternRegex, err := buildPatternRegex(patternStr)
@@ -36,12 +36,12 @@ func (p pattern) match(testPath string) (bool, error) {
 		prefix := p.pattern
 
 		// Strip the leading slash as we're anchored to the root already
-		if prefix[0] == os.PathSeparator {
+		if prefix[0] == '/' {
 			prefix = prefix[1:]
 		}
 
 		// If the pattern ends with a slash we can do a simple prefix match
-		if prefix[len(prefix)-1] == os.PathSeparator {
+		if prefix[len(prefix)-1] == '/' {
 			return strings.HasPrefix(testPath, prefix), nil
 		}
 
@@ -95,7 +95,7 @@ func buildPatternRegex(pattern string) (*regexp.Regexp, error) {
 		segs[len(segs)-1] = "**"
 	}
 
-	sep := string(os.PathSeparator)
+	sep := "/"
 
 	lastSegIndex := len(segs) - 1
 	needSlash := false

--- a/match.go
+++ b/match.go
@@ -2,7 +2,7 @@ package codeowners
 
 import (
 	"fmt"
-	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -32,6 +32,9 @@ func newPattern(patternStr string) (pattern, error) {
 
 // match tests if the path provided matches the pattern
 func (p pattern) match(testPath string) (bool, error) {
+	// Normalize Windows-style path separators to forward slashes
+	testPath = filepath.ToSlash(testPath)
+
 	if p.leftAnchoredLiteral {
 		prefix := p.pattern
 
@@ -51,7 +54,7 @@ func (p pattern) match(testPath string) (bool, error) {
 		}
 
 		// Otherwise check if the test path is a subdirectory of the pattern
-		if len(testPath) > len(prefix) && testPath[len(prefix)] == os.PathSeparator {
+		if len(testPath) > len(prefix) && testPath[len(prefix)] == '/' {
 			return testPath[:len(prefix)] == prefix, nil
 		}
 


### PR DESCRIPTION
Run tests on Windows and fix path separator issues that crop up when running on Windows.

Resolves https://github.com/hmarr/codeowners/issues/15