### PR TITLE
fix: email address regexp

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	emailRegexp    = regexp.MustCompile(`\A[A-Z0-9a-z\._%\+\-]+@[A-Za-z0-9\.\-]+\.[A-Za-z]{2,6}\z`)
+	emailRegexp    = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 	teamRegexp     = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+\/[a-zA-Z0-9_\-]+)\z`)
 	usernameRegexp = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+)\z`)
 )

--- a/parse_test.go
+++ b/parse_test.go
@@ -39,6 +39,22 @@ func TestParseRule(t *testing.T) {
 			},
 		},
 		{
+			name: "email owners with localhost",
+			rule: "file.txt foo@localhost",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "file.txt"),
+				Owners:  []Owner{{Value: "foo@localhost", Type: "email"}},
+			},
+		},
+		{
+			name: "email owners with long tdl",
+			rule: "file.txt foo@mail.localhost",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "file.txt"),
+				Owners:  []Owner{{Value: "foo@mail.localhost", Type: "email"}},
+			},
+		},
+		{
 			name: "multiple owners",
 			rule: "file.txt @user @org/team foo@example.com",
 			expected: Rule{


### PR DESCRIPTION
Hey,

I was playing around with this library when I noticed that the regexp for emails was very restrictive. My setup looks something like this:

CODEOWNERS
```
* haveachin@mail.localhost
```
main.go
```go
package main

import (
	"log"
	"os"

	"github.com/hmarr/codeowners"
)

func main() {
	f, err := os.Open("CODEOWNERS")
	if err != nil {
		log.Fatal(err)
	}

	_, err = codeowners.ParseFile(f)
	if err != nil {
		log.Fatal(err)
	}
}
```

I was getting this error:
```
line 1: invalid owner format 'haveachin@mail.localhost' at position 3
```

Here is a playground link if you want to try it yourself: https://play.golang.com/p/rxZi4JJA9JT

I swapped the current email regexp with a less restrictive one. This is the same regexp that is implemented in the HTML validation of an email input field: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address