### PR TITLE
Parse options w/ option for overriding owner matchers

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -32,12 +32,14 @@ const (
 )
 
 var DefaultMatchers = []Matcher{
-	MatcherFunc(EmailMatcher),
-	MatcherFunc(TeamMatcher),
-	MatcherFunc(UsernameMatcher),
+	MatcherFunc(MatchEmail),
+	MatcherFunc(MatchTeam),
+	MatcherFunc(MatchUsername),
 }
 
 type Matcher interface {
+	// Matches give string agains a pattern e.g. a regexp.
+	// Should return ErrNoMatch if the pattern doesn't match.
 	Match(s string) (Owner, error)
 }
 
@@ -47,7 +49,7 @@ func (f MatcherFunc) Match(s string) (Owner, error) {
 	return f(s)
 }
 
-func EmailMatcher(s string) (Owner, error) {
+func MatchEmail(s string) (Owner, error) {
 	match := emailRegexp.FindStringSubmatch(s)
 	if match == nil {
 		return Owner{}, ErrNoMatch
@@ -56,7 +58,7 @@ func EmailMatcher(s string) (Owner, error) {
 	return Owner{Value: match[0], Type: EmailOwner}, nil
 }
 
-func TeamMatcher(s string) (Owner, error) {
+func MatchTeam(s string) (Owner, error) {
 	match := teamRegexp.FindStringSubmatch(s)
 	if match == nil {
 		return Owner{}, ErrNoMatch
@@ -65,7 +67,7 @@ func TeamMatcher(s string) (Owner, error) {
 	return Owner{Value: match[1], Type: TeamOwner}, nil
 }
 
-func UsernameMatcher(s string) (Owner, error) {
+func MatchUsername(s string) (Owner, error) {
 	match := usernameRegexp.FindStringSubmatch(s)
 	if match == nil {
 		return Owner{}, ErrNoMatch

--- a/parse_test.go
+++ b/parse_test.go
@@ -147,8 +147,8 @@ func TestParseRule(t *testing.T) {
 			name: "email owners without email matcher",
 			rule: "file.txt foo@example.com",
 			matcher: []Matcher{
-				MatcherFunc(TeamMatcher),
-				MatcherFunc(UsernameMatcher),
+				MatcherFunc(MatchTeam),
+				MatcherFunc(MatchUsername),
 			},
 			err: "invalid owner format 'foo@example.com' at position 10",
 		},
@@ -156,8 +156,8 @@ func TestParseRule(t *testing.T) {
 			name: "team owners without team matcher",
 			rule: "file.txt @org/team",
 			matcher: []Matcher{
-				MatcherFunc(EmailMatcher),
-				MatcherFunc(UsernameMatcher),
+				MatcherFunc(MatchEmail),
+				MatcherFunc(MatchUsername),
 			},
 			err: "invalid owner format '@org/team' at position 10",
 		},
@@ -165,8 +165,8 @@ func TestParseRule(t *testing.T) {
 			name: "username owners without username matcher",
 			rule: "file.txt @user",
 			matcher: []Matcher{
-				MatcherFunc(EmailMatcher),
-				MatcherFunc(TeamMatcher),
+				MatcherFunc(MatchEmail),
+				MatcherFunc(MatchTeam),
 			},
 			err: "invalid owner format '@user' at position 10",
 		},

--- a/parse_test.go
+++ b/parse_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestParseRule(t *testing.T) {
 	examples := []struct {
-		name     string
-		rule     string
-		matcher  []Matcher
-		expected Rule
-		err      string
+		name          string
+		rule          string
+		ownerMatchers []OwnerMatcher
+		expected      Rule
+		err           string
 	}{
 		// Success cases
 		{
@@ -146,27 +146,27 @@ func TestParseRule(t *testing.T) {
 		{
 			name: "email owners without email matcher",
 			rule: "file.txt foo@example.com",
-			matcher: []Matcher{
-				MatcherFunc(MatchTeam),
-				MatcherFunc(MatchUsername),
+			ownerMatchers: []OwnerMatcher{
+				OwnerMatchFunc(MatchTeamOwner),
+				OwnerMatchFunc(MatchUsernameOwner),
 			},
 			err: "invalid owner format 'foo@example.com' at position 10",
 		},
 		{
 			name: "team owners without team matcher",
 			rule: "file.txt @org/team",
-			matcher: []Matcher{
-				MatcherFunc(MatchEmail),
-				MatcherFunc(MatchUsername),
+			ownerMatchers: []OwnerMatcher{
+				OwnerMatchFunc(MatchEmailOwner),
+				OwnerMatchFunc(MatchUsernameOwner),
 			},
 			err: "invalid owner format '@org/team' at position 10",
 		},
 		{
 			name: "username owners without username matcher",
 			rule: "file.txt @user",
-			matcher: []Matcher{
-				MatcherFunc(MatchEmail),
-				MatcherFunc(MatchTeam),
+			ownerMatchers: []OwnerMatcher{
+				OwnerMatchFunc(MatchEmailOwner),
+				OwnerMatchFunc(MatchTeamOwner),
 			},
 			err: "invalid owner format '@user' at position 10",
 		},
@@ -174,7 +174,11 @@ func TestParseRule(t *testing.T) {
 
 	for _, e := range examples {
 		t.Run("parses "+e.name, func(t *testing.T) {
-			actual, err := parseRule(e.rule, e.matcher)
+			opts := parseOptions{ownerMatchers: DefaultOwnerMatchers}
+			if e.ownerMatchers != nil {
+				opts.ownerMatchers = e.ownerMatchers
+			}
+			actual, err := parseRule(e.rule, opts)
 			if e.err != "" {
 				assert.EqualError(t, err, e.err)
 			} else {


### PR DESCRIPTION
@haveachin - this takes https://github.com/hmarr/codeowners/pull/19 and adds a commit that
- renames `Matcher` to `OwnerMatcher` as "matcher" is already used widely in the codebase for matching codeowners patterns
- changes the signature of `ParseFile` to accept parse options (e.g. `WithOwnerMatchers`) rather than the matchers themselves, as it's likely we'll want to add more parser options in the future (e.g. to support the GitLab sections syntax)

Thanks for your PR—have a look at these changes and LMK what you think. I'm also happy to push the commit to your branch if you turn on the "Allow edits from maintainers" flag.