### PR TITLE
Update file parsing to handle lines with only whitespace.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func Example() {
-	f := bytes.NewBufferString("src/**/*.c @acme/c-developers")
+	f := bytes.NewBufferString(`src/**/*.c @acme/c-developers
+# The following line should be ignored; it contains only spaces and tabs` +
+		" \t\nsrc/**/*.go @acme/go-developers")
 	ruleset, err := codeowners.ParseFile(f)
 	if err != nil {
 		panic(err)
@@ -19,9 +21,13 @@ func Example() {
 
 	match, err = ruleset.Match("src/foo.rs")
 	fmt.Println(match)
+
+	match, err = ruleset.Match("src/go/bar/bar.go")
+	fmt.Println(match.Owners)
 	// Output:
 	// [@acme/c-developers]
 	// <nil>
+	// [@acme/go-developers]
 }
 
 func ExampleParseFile() {

--- a/parse.go
+++ b/parse.go
@@ -30,7 +30,7 @@ func ParseFile(f io.Reader) (Ruleset, error) {
 		line := scanner.Text()
 
 		// Ignore blank lines and comments
-		if len(line) == 0 || line[0] == '#' {
+		if len(strings.TrimSpace(line)) == 0 || line[0] == '#' {
 			continue
 		}
 


### PR DESCRIPTION
This commit updates file parsing so that lines that contain solely whitespace (as defined by by Unicode) are ignored. It's fairly common for people to accidentally create CODEOWNERS files with lines containing solely whitespace, and as it's semantically meaningless, it's better to ignore them then raise an error.