### PR TITLE
Implement basic section support

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -122,6 +122,12 @@ type Rule struct {
 	pattern    pattern
 }
 
+type Section struct {
+	Name    string
+	Owners  []Owner
+	Comment string
+}
+
 // RawPattern returns the rule's gitignore-style path pattern.
 func (r Rule) RawPattern() string {
 	return r.pattern.pattern
@@ -139,6 +145,8 @@ const (
 	TeamOwner string = "team"
 	// UsernameOwner is the owner type for GitHub usernames.
 	UsernameOwner string = "username"
+	// GroupOwner is the owner type for Gitlab groups.
+	GroupOwner string = "group"
 )
 
 // Owner represents an owner found in a rule.

--- a/example_test.go
+++ b/example_test.go
@@ -106,3 +106,47 @@ func ExampleRuleset_Match() {
 	// src/foo/bar.go true
 	// src/foo.rs false
 }
+
+func ExampleRuleset_Match_section() {
+	f := bytes.NewBufferString(`[SECTION] @the-a-team
+src
+src-b @user-b
+`)
+	ruleset, _ := codeowners.ParseFile(f)
+	match, _ := ruleset.Match("src")
+	fmt.Println("src", match != nil)
+	fmt.Println(ruleset[0].Owners[0].String())
+	match, _ = ruleset.Match("src-b")
+	fmt.Println("src-b", match != nil)
+	fmt.Println(ruleset[1].Owners[0].String())
+	// Output:
+	// src true
+	// @the-a-team
+	// src-b true
+	// @user-b
+}
+
+func ExampleRuleset_Match_section_groups() {
+	f := bytes.NewBufferString(`[SECTION] @the/a/group
+src
+src-b @user-b
+src-c @the/c/group
+`)
+	ruleset, _ := codeowners.ParseFile(f)
+	match, _ := ruleset.Match("src")
+	fmt.Println("src", match != nil)
+	fmt.Println(ruleset[0].Owners[0].String())
+	match, _ = ruleset.Match("src-b")
+	fmt.Println("src-b", match != nil)
+	fmt.Println(ruleset[1].Owners[0].String())
+	match, _ = ruleset.Match("src-c")
+	fmt.Println("src-c", match != nil)
+	fmt.Println(ruleset[2].Owners[0].String())
+	// Output:
+	// src true
+	// @the/a/group
+	// src-b true
+	// @user-b
+	// src-c true
+	// @the/c/group
+}

--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func Example() {
-	f := bytes.NewBufferString("src/**/*.c @acme/c-developers")
+	f := bytes.NewBufferString(`src/**/*.c @acme/c-developers
+# The following line should be ignored; it contains only spaces and tabs` +
+		" \t\nsrc/**/*.go @acme/go-developers")
 	ruleset, err := codeowners.ParseFile(f)
 	if err != nil {
 		panic(err)
@@ -19,9 +21,13 @@ func Example() {
 
 	match, err = ruleset.Match("src/foo.rs")
 	fmt.Println(match)
+
+	match, err = ruleset.Match("src/go/bar/bar.go")
+	fmt.Println(match.Owners)
 	// Output:
 	// [@acme/c-developers]
 	// <nil>
+	// [@acme/go-developers]
 }
 
 func ExampleParseFile() {

--- a/parse.go
+++ b/parse.go
@@ -32,12 +32,14 @@ const (
 )
 
 var DefaultMatchers = []Matcher{
-	MatcherFunc(EmailMatcher),
-	MatcherFunc(TeamMatcher),
-	MatcherFunc(UsernameMatcher),
+	MatcherFunc(MatchEmail),
+	MatcherFunc(MatchTeam),
+	MatcherFunc(MatchUsername),
 }
 
 type Matcher interface {
+	// Matches give string agains a pattern e.g. a regexp.
+	// Should return ErrNoMatch if the pattern doesn't match.
 	Match(s string) (Owner, error)
 }
 
@@ -47,7 +49,7 @@ func (f MatcherFunc) Match(s string) (Owner, error) {
 	return f(s)
 }
 
-func EmailMatcher(s string) (Owner, error) {
+func MatchEmail(s string) (Owner, error) {
 	match := emailRegexp.FindStringSubmatch(s)
 	if match == nil {
 		return Owner{}, ErrNoMatch
@@ -56,7 +58,7 @@ func EmailMatcher(s string) (Owner, error) {
 	return Owner{Value: match[0], Type: EmailOwner}, nil
 }
 
-func TeamMatcher(s string) (Owner, error) {
+func MatchTeam(s string) (Owner, error) {
 	match := teamRegexp.FindStringSubmatch(s)
 	if match == nil {
 		return Owner{}, ErrNoMatch
@@ -65,7 +67,7 @@ func TeamMatcher(s string) (Owner, error) {
 	return Owner{Value: match[1], Type: TeamOwner}, nil
 }
 
-func UsernameMatcher(s string) (Owner, error) {
+func MatchUsername(s string) (Owner, error) {
 	match := usernameRegexp.FindStringSubmatch(s)
 	if match == nil {
 		return Owner{}, ErrNoMatch

--- a/parse.go
+++ b/parse.go
@@ -30,7 +30,7 @@ func ParseFile(f io.Reader) (Ruleset, error) {
 		line := scanner.Text()
 
 		// Ignore blank lines and comments
-		if len(line) == 0 || line[0] == '#' {
+		if len(strings.TrimSpace(line)) == 0 || line[0] == '#' {
 			continue
 		}
 

--- a/parse.go
+++ b/parse.go
@@ -42,12 +42,14 @@ var (
 	emailRegexp    = regexp.MustCompile(`\A[A-Z0-9a-z\._%\+\-]+@[A-Za-z0-9\.\-]+\.[A-Za-z]{2,6}\z`)
 	teamRegexp     = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+\/[a-zA-Z0-9_\-]+)\z`)
 	usernameRegexp = regexp.MustCompile(`\A@([a-zA-Z0-9\-_]+)\z`)
+	groupRegexp    = regexp.MustCompile(`\A@(([a-zA-Z0-9\-_]+)(/[a-zA-Z0-9\-_]+)*)\z`)
 )
 
 var DefaultOwnerMatchers = []OwnerMatcher{
 	OwnerMatchFunc(MatchEmailOwner),
 	OwnerMatchFunc(MatchTeamOwner),
 	OwnerMatchFunc(MatchUsernameOwner),
+	OwnerMatchFunc(MatchGroupOwner),
 }
 
 type OwnerMatchFunc func(s string) (Owner, error)
@@ -83,6 +85,15 @@ func MatchUsernameOwner(s string) (Owner, error) {
 	return Owner{Value: match[1], Type: UsernameOwner}, nil
 }
 
+func MatchGroupOwner(s string) (Owner, error) {
+	match := groupRegexp.FindStringSubmatch(s)
+	if match == nil {
+		return Owner{}, ErrNoMatch
+	}
+
+	return Owner{Value: match[1], Type: GroupOwner}, nil
+}
+
 // ParseFile parses a CODEOWNERS file, returning a set of rules.
 // To override the default owner matchers, pass WithOwnerMatchers() as an option.
 func ParseFile(f io.Reader, options ...parseOption) (Ruleset, error) {
@@ -91,6 +102,7 @@ func ParseFile(f io.Reader, options ...parseOption) (Ruleset, error) {
 		opt(&opts)
 	}
 
+	sectionOwners := []Owner{}
 	rules := Ruleset{}
 	scanner := bufio.NewScanner(f)
 	lineNo := 0
@@ -103,7 +115,18 @@ func ParseFile(f io.Reader, options ...parseOption) (Ruleset, error) {
 			continue
 		}
 
-		rule, err := parseRule(line, opts)
+		if isSectionBraces(rune(line[0])) {
+			section, err := parseSection(line, opts)
+			if err != nil {
+				return nil, fmt.Errorf("line %d: %w", lineNo, err)
+			}
+
+			sectionOwners = section.Owners
+
+			continue
+		}
+
+		rule, err := parseRule(line, opts, sectionOwners)
 		if err != nil {
 			return nil, fmt.Errorf("line %d: %w", lineNo, err)
 		}
@@ -116,10 +139,101 @@ func ParseFile(f io.Reader, options ...parseOption) (Ruleset, error) {
 const (
 	statePattern = iota + 1
 	stateOwners
+	stateSection
 )
 
+// parseSection parses a single line of a CODEOWNERS file, returning a Rule struct
+func parseSection(ruleStr string, opts parseOptions) (Section, error) {
+	s := Section{}
+
+	state := stateSection
+	escaped := false
+	buf := bytes.Buffer{}
+	for i, ch := range strings.TrimSpace(ruleStr) {
+		// Comments consume the rest of the line and stop further parsing
+		if ch == '#' {
+			s.Comment = strings.TrimSpace(ruleStr[i+1:])
+			break
+		}
+
+		switch state {
+		case stateSection:
+			switch {
+			case ch == '\\':
+				// Escape the next character (important for whitespace while parsing), but
+				// don't lose the backslash as it's part of the pattern
+				escaped = true
+				buf.WriteRune(ch)
+				continue
+			case isSectionBraces(ch):
+				continue
+
+			case isSectionChar(ch) || (isWhitespace(ch) && escaped):
+				// Keep any valid pattern characters and escaped whitespace
+				buf.WriteRune(ch)
+
+			case isWhitespace(ch) && !escaped:
+				s.Name = buf.String()
+				buf.Reset()
+				state = stateOwners
+
+			default:
+				return s, fmt.Errorf("section: unexpected character '%c' at position %d", ch, i+1)
+			}
+
+		case stateOwners:
+			switch {
+			case isWhitespace(ch):
+				// Whitespace means we've reached the end of the owner or we're just chomping
+				// through whitespace before or after owner declarations
+				if buf.Len() > 0 {
+					ownerStr := buf.String()
+					owner, err := newOwner(ownerStr, opts.ownerMatchers)
+					if err != nil {
+						return s, fmt.Errorf("section: %w at position %d", err, i+1-len(ownerStr))
+					}
+
+					s.Owners = append(s.Owners, owner)
+					buf.Reset()
+				}
+
+			case isOwnersChar(ch):
+				// Write valid owner characters to the buffer
+				buf.WriteRune(ch)
+
+			default:
+				return s, fmt.Errorf("section: unexpected character '%c' at position %d", ch, i+1)
+			}
+		}
+	}
+
+	escaped = false
+
+	// We've finished consuming the line, but we might still have content in the buffer
+	// if the line didn't end with a separator (whitespace)
+	switch state {
+	case stateSection:
+		s.Name = buf.String()
+
+	case stateOwners:
+		// If there's an owner left in the buffer, don't leave it behind
+		if buf.Len() > 0 {
+			ownerStr := buf.String()
+			owner, err := newOwner(ownerStr, opts.ownerMatchers)
+			if err != nil {
+				return s, fmt.Errorf("%s at position %d", err.Error(), len(ruleStr)+1-len(ownerStr))
+			}
+
+			s.Owners = append(s.Owners, owner)
+		}
+
+	}
+
+	return s, nil
+}
+
 // parseRule parses a single line of a CODEOWNERS file, returning a Rule struct
-func parseRule(ruleStr string, opts parseOptions) (Rule, error) {
+func parseRule(ruleStr string, opts parseOptions, inheritedOwners []Owner) (Rule, error) {
 	r := Rule{}
 
 	state := statePattern
@@ -213,6 +327,10 @@ func parseRule(ruleStr string, opts parseOptions) (Rule, error) {
 		}
 	}
 
+	if len(r.Owners) == 0 {
+		r.Owners = inheritedOwners
+	}
+
 	return r, nil
 }
 
@@ -258,4 +376,22 @@ func isOwnersChar(ch rune) bool {
 		return true
 	}
 	return isAlphanumeric(ch)
+}
+
+// isSectionChar matches characters that are allowed in owner definitions
+func isSectionChar(ch rune) bool {
+	switch ch {
+	case '.', '@', '/', '_', '%', '+', '-':
+		return true
+	}
+	return isAlphanumeric(ch)
+}
+
+// isSectionBraces matches characters that are allowed in section definitions
+func isSectionBraces(ch rune) bool {
+	switch ch {
+	case '[', ']':
+		return true
+	}
+	return false
 }

--- a/parse.go
+++ b/parse.go
@@ -12,7 +12,7 @@ import (
 var (
 	emailRegexp    = regexp.MustCompile(`\A[A-Z0-9a-z\._%\+\-]+@[A-Za-z0-9\.\-]+\.[A-Za-z]{2,6}\z`)
 	teamRegexp     = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+\/[a-zA-Z0-9_\-]+)\z`)
-	usernameRegexp = regexp.MustCompile(`\A@([a-zA-Z0-9\-]+)\z`)
+	usernameRegexp = regexp.MustCompile(`\A@([a-zA-Z0-9\-_]+)\z`)
 )
 
 const (

--- a/parse_test.go
+++ b/parse_test.go
@@ -147,8 +147,8 @@ func TestParseRule(t *testing.T) {
 			name: "email owners without email matcher",
 			rule: "file.txt foo@example.com",
 			matcher: []Matcher{
-				MatcherFunc(TeamMatcher),
-				MatcherFunc(UsernameMatcher),
+				MatcherFunc(MatchTeam),
+				MatcherFunc(MatchUsername),
 			},
 			err: "invalid owner format 'foo@example.com' at position 10",
 		},
@@ -156,8 +156,8 @@ func TestParseRule(t *testing.T) {
 			name: "team owners without team matcher",
 			rule: "file.txt @org/team",
 			matcher: []Matcher{
-				MatcherFunc(EmailMatcher),
-				MatcherFunc(UsernameMatcher),
+				MatcherFunc(MatchEmail),
+				MatcherFunc(MatchUsername),
 			},
 			err: "invalid owner format '@org/team' at position 10",
 		},
@@ -165,8 +165,8 @@ func TestParseRule(t *testing.T) {
 			name: "username owners without username matcher",
 			rule: "file.txt @user",
 			matcher: []Matcher{
-				MatcherFunc(EmailMatcher),
-				MatcherFunc(TeamMatcher),
+				MatcherFunc(MatchEmail),
+				MatcherFunc(MatchTeam),
 			},
 			err: "invalid owner format '@user' at position 10",
 		},

--- a/parse_test.go
+++ b/parse_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestParseRule(t *testing.T) {
 	examples := []struct {
-		name     string
-		rule     string
-		matcher  []Matcher
-		expected Rule
-		err      string
+		name          string
+		rule          string
+		ownerMatchers []OwnerMatcher
+		expected      Rule
+		err           string
 	}{
 		// Success cases
 		{
@@ -146,27 +146,27 @@ func TestParseRule(t *testing.T) {
 		{
 			name: "email owners without email matcher",
 			rule: "file.txt foo@example.com",
-			matcher: []Matcher{
-				MatcherFunc(MatchTeam),
-				MatcherFunc(MatchUsername),
+			ownerMatchers: []OwnerMatcher{
+				OwnerMatchFunc(MatchTeamOwner),
+				OwnerMatchFunc(MatchUsernameOwner),
 			},
 			err: "invalid owner format 'foo@example.com' at position 10",
 		},
 		{
 			name: "team owners without team matcher",
 			rule: "file.txt @org/team",
-			matcher: []Matcher{
-				MatcherFunc(MatchEmail),
-				MatcherFunc(MatchUsername),
+			ownerMatchers: []OwnerMatcher{
+				OwnerMatchFunc(MatchEmailOwner),
+				OwnerMatchFunc(MatchUsernameOwner),
 			},
 			err: "invalid owner format '@org/team' at position 10",
 		},
 		{
 			name: "username owners without username matcher",
 			rule: "file.txt @user",
-			matcher: []Matcher{
-				MatcherFunc(MatchEmail),
-				MatcherFunc(MatchTeam),
+			ownerMatchers: []OwnerMatcher{
+				OwnerMatchFunc(MatchEmailOwner),
+				OwnerMatchFunc(MatchTeamOwner),
 			},
 			err: "invalid owner format '@user' at position 10",
 		},
@@ -174,7 +174,11 @@ func TestParseRule(t *testing.T) {
 
 	for _, e := range examples {
 		t.Run("parses "+e.name, func(t *testing.T) {
-			actual, err := parseRule(e.rule, e.matcher)
+			opts := parseOptions{ownerMatchers: DefaultOwnerMatchers}
+			if e.ownerMatchers != nil {
+				opts.ownerMatchers = e.ownerMatchers
+			}
+			actual, err := parseRule(e.rule, opts)
 			if e.err != "" {
 				assert.EqualError(t, err, e.err)
 			} else {


### PR DESCRIPTION
This PR also includes the PRs #19, #24, #25 since I considered them useful.

Todo's are support for approval configuration, which I am not in immediate need of.

I haven't put in more time than needed to get it working without breaking existing tests.

Sorry I haven't implemented a toggle for the support, yet. Easiest thing would be to add another parser package and have an interface to work against.