### PR TITLE
Support gitlab sections

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -122,6 +122,14 @@ type Rule struct {
 	pattern    pattern
 }
 
+type Section struct {
+	Name             string
+	Owners           []Owner
+	Comment          string
+	ApprovalOptional bool
+	ApprovalCount    int
+}
+
 // RawPattern returns the rule's gitignore-style path pattern.
 func (r Rule) RawPattern() string {
 	return r.pattern.pattern

--- a/codeowners.go
+++ b/codeowners.go
@@ -39,21 +39,21 @@ import (
 // LoadFileFromStandardLocation loads and parses a CODEOWNERS file at one of the
 // standard locations for CODEOWNERS files (./, .github/, docs/). If run from a
 // git repository, all paths are relative to the repository root.
-func LoadFileFromStandardLocation() (Ruleset, error) {
+func LoadFileFromStandardLocation(options ...ParseOption) (Ruleset, error) {
 	path := findFileAtStandardLocation()
 	if path == "" {
 		return nil, fmt.Errorf("could not find CODEOWNERS file at any of the standard locations")
 	}
-	return LoadFile(path)
+	return LoadFile(path, options...)
 }
 
 // LoadFile loads and parses a CODEOWNERS file at the path specified.
-func LoadFile(path string) (Ruleset, error) {
+func LoadFile(path string, options ...ParseOption) (Ruleset, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	return ParseFile(f)
+	return ParseFile(f, options...)
 }
 
 // findFileAtStandardLocation loops through the standard locations for

--- a/example_test.go
+++ b/example_test.go
@@ -100,3 +100,77 @@ func ExampleRuleset_Match() {
 	// src/foo/bar.go true
 	// src/foo.rs false
 }
+
+func ExampleRuleset_Match_section() {
+	f := bytes.NewBufferString(`[SECTION] @the-a-team
+src
+src-b @user-b
+`)
+	ruleset, _ := codeowners.ParseFile(f, codeowners.WithSectionSupport())
+	match, _ := ruleset.Match("src")
+	fmt.Println("src", match != nil)
+	fmt.Println(ruleset[0].Owners[0].String())
+	match, _ = ruleset.Match("src-b")
+	fmt.Println("src-b", match != nil)
+	fmt.Println(ruleset[1].Owners[0].String())
+	// Output:
+	// src true
+	// @the-a-team
+	// src-b true
+	// @user-b
+}
+
+func ExampleRuleset_Match_section_groups() {
+	f := bytes.NewBufferString(`[SECTION] @the/a/group
+src
+src-b @user-b
+src-c @the/c/group
+`)
+	ruleset, _ := codeowners.ParseFile(f, codeowners.WithSectionSupport())
+	match, _ := ruleset.Match("src")
+	fmt.Println("src", match != nil)
+	fmt.Println(ruleset[0].Owners[0].String())
+	match, _ = ruleset.Match("src-b")
+	fmt.Println("src-b", match != nil)
+	fmt.Println(ruleset[1].Owners[0].String())
+	match, _ = ruleset.Match("src-c")
+	fmt.Println("src-c", match != nil)
+	fmt.Println(ruleset[2].Owners[0].String())
+	// Output:
+	// src true
+	// @the/a/group
+	// src-b true
+	// @user-b
+	// src-c true
+	// @the/c/group
+}
+
+func ExampleRuleset_Match_section_groups_multiple() {
+	f := bytes.NewBufferString(`[SECTION] @the/a/group
+* @other
+
+[SECTION-B] @the/b/group
+b-src
+b-src-b @user-b
+b-src-c @the/c/group
+
+[SECTION-C]
+`)
+	ruleset, _ := codeowners.ParseFile(f, codeowners.WithSectionSupport())
+	match, _ := ruleset.Match("b-src")
+	fmt.Println("b-src", match != nil)
+	fmt.Println(ruleset[1].Owners[0].String())
+	match, _ = ruleset.Match("b-src-b")
+	fmt.Println("b-src-b", match != nil)
+	fmt.Println(ruleset[2].Owners[0].String())
+	match, _ = ruleset.Match("b-src-c")
+	fmt.Println("b-src-c", match != nil)
+	fmt.Println(ruleset[3].Owners[0].String())
+	// Output:
+	// b-src true
+	// @the/b/group
+	// b-src-b true
+	// @user-b
+	// b-src-c true
+	// @the/c/group
+}

--- a/parse.go
+++ b/parse.go
@@ -11,20 +11,20 @@ import (
 	"strings"
 )
 
-type parseOption func(*parseOptions)
+type ParseOption func(*parseOptions)
 
 type parseOptions struct {
 	ownerMatchers  []OwnerMatcher
 	sectionSupport bool
 }
 
-func WithSectionSupport() parseOption {
+func WithSectionSupport() ParseOption {
 	return func(opts *parseOptions) {
 		opts.sectionSupport = true
 	}
 }
 
-func WithOwnerMatchers(mm []OwnerMatcher) parseOption {
+func WithOwnerMatchers(mm []OwnerMatcher) ParseOption {
 	return func(opts *parseOptions) {
 		opts.ownerMatchers = mm
 	}
@@ -105,7 +105,7 @@ func MatchUsernameOwner(s string) (Owner, error) {
 
 // ParseFile parses a CODEOWNERS file, returning a set of rules.
 // To override the default owner matchers, pass WithOwnerMatchers() as an option.
-func ParseFile(f io.Reader, options ...parseOption) (Ruleset, error) {
+func ParseFile(f io.Reader, options ...ParseOption) (Ruleset, error) {
 	opts := parseOptions{ownerMatchers: DefaultOwnerMatchers}
 	for _, opt := range options {
 		opt(&opts)

--- a/parse_test.go
+++ b/parse_test.go
@@ -96,6 +96,22 @@ func TestParseRule(t *testing.T) {
 	}{
 		// Success cases
 		{
+			name: "username with dots",
+			rule: "file.txt @user.name",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "file.txt"),
+				Owners:  []Owner{{Value: "user.name", Type: "username"}},
+			},
+		},
+		{
+			name: "username with underscore",
+			rule: "file.txt @user_name",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "file.txt"),
+				Owners:  []Owner{{Value: "user_name", Type: "username"}},
+			},
+		},
+		{
 			name: "username owners",
 			rule: "file.txt @user",
 			expected: Rule{
@@ -256,6 +272,11 @@ func TestParseRule(t *testing.T) {
 			err:  "invalid owner format 'missing-at-sign' at position 10",
 		},
 		{
+			name: "malformed owners trailing dot",
+			rule: "file.txt @trailing-dot.",
+			err:  "invalid owner format '@trailing-dot.' at position 10",
+		},
+		{
 			name: "email owners without email matcher",
 			rule: "file.txt foo@example.com",
 			ownerMatchers: []OwnerMatcher{
@@ -290,7 +311,107 @@ func TestParseRule(t *testing.T) {
 			if e.ownerMatchers != nil {
 				opts.ownerMatchers = e.ownerMatchers
 			}
-			actual, err := parseRule(e.rule, opts)
+			actual, err := parseRule(e.rule, opts, nil)
+			if e.err != "" {
+				assert.EqualError(t, err, e.err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, e.expected, actual)
+			}
+		})
+	}
+}
+
+func TestParseSection(t *testing.T) {
+	examples := []struct {
+		name          string
+		rule          string
+		ownerMatchers []OwnerMatcher
+		expected      Section
+		err           string
+	}{
+		// Success cases
+		{
+			name: "match sections",
+			rule: "[Section]",
+			expected: Section{
+				Name:    "Section",
+				Owners:  nil,
+				Comment: "",
+			},
+		},
+		{
+			name: "match sections with spaces",
+			rule: "[Section Spaces]",
+			expected: Section{
+				Name:    "Section Spaces",
+				Owners:  nil,
+				Comment: "",
+			},
+		},
+		{
+			name: "match sections with optional approval",
+			rule: "^[Section]",
+			expected: Section{
+				Name:             "Section",
+				Owners:           nil,
+				Comment:          "",
+				ApprovalOptional: true,
+			},
+		},
+		{
+			name: "match sections with approval count",
+			rule: "^[Section][2]",
+			expected: Section{
+				Name:             "Section",
+				Owners:           nil,
+				Comment:          "",
+				ApprovalOptional: true,
+				ApprovalCount:    2,
+			},
+		},
+		{
+			name: "match sections with owner",
+			rule: "[Section-B-User] @the-b-user",
+			expected: Section{
+				Name:    "Section-B-User",
+				Owners:  []Owner{{Value: "the-b-user", Type: "username"}},
+				Comment: "",
+			},
+		},
+		{
+			name: "match sections with comment",
+			rule: "[Section] # some comment",
+			expected: Section{
+				Name:    "Section",
+				Owners:  nil,
+				Comment: "some comment",
+			},
+		},
+		{
+			name: "match sections with owner and comment",
+			rule: "[Section] @the/a/team # some comment",
+			expected: Section{
+				Name:    "Section",
+				Owners:  []Owner{{Value: "the/a/team", Type: "team"}},
+				Comment: "some comment",
+			},
+			ownerMatchers: []OwnerMatcher{
+				OwnerMatchFunc(MatchTeamOwner),
+			},
+		},
+
+		// Error cases
+		// TODO
+	}
+
+	for _, e := range examples {
+		t.Run("parses Sections "+e.name, func(t *testing.T) {
+			opts := parseOptions{ownerMatchers: DefaultOwnerMatchers}
+			if e.ownerMatchers != nil {
+				opts.ownerMatchers = e.ownerMatchers
+			}
+			actual, err := parseSection(e.rule, opts)
 			if e.err != "" {
 				assert.EqualError(t, err, e.err)
 			} else {


### PR DESCRIPTION
- added section support with or without approval count and optional flag
- refactored cmd/main.go for cleaner ParseOptions passing ([see](https://github.com/hmarr/codeowners/compare/main...rwese:support-gitlab-sections?expand=1#diff-2cc3a1b72c1e0ad4c9da8c7601c75cbfc3c28f3d987bc43ed9fbf6ae4fa38444L122-L126))

If there are changes you need let me know.