### PR TITLE
Allow pipe and curly braces in patterns

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -257,7 +257,7 @@ func isAlphanumeric(ch rune) bool {
 // isPatternChar matches characters that are allowed in patterns
 func isPatternChar(ch rune) bool {
 	switch ch {
-	case '*', '?', '.', '/', '@', '_', '+', '-', '\\', '(', ')':
+	case '*', '?', '.', '/', '@', '_', '+', '-', '\\', '(', ')', '|', '{', '}':
 		return true
 	}
 	return isAlphanumeric(ch)

--- a/parse_test.go
+++ b/parse_test.go
@@ -233,17 +233,52 @@ func TestParseRule(t *testing.T) {
 				Comment: "",
 			},
 		},
+		{
+			name: "pattern with pipe character '|'",
+			rule: "foo|bar|baz @org/team",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "foo|bar|baz"),
+				Owners:  []Owner{{Value: "org/team", Type: "team"}},
+			},
+		},
+		{
+			name: "pattern with left curly brace '{'",
+			rule: "foo{bar.txt @org/team",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "foo{bar.txt"),
+				Owners:  []Owner{{Value: "org/team", Type: "team"}},
+			},
+		},
+		{
+			name: "pattern with right curly brace '}'",
+			rule: "foo}bar.txt @org/team",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "foo}bar.txt"),
+				Owners:  []Owner{{Value: "org/team", Type: "team"}},
+			},
+		},
+		{
+			name: "pattern with curly braces '{' and '}'",
+			rule: "foo{bar}.txt @org/team",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "foo{bar}.txt"),
+				Owners:  []Owner{{Value: "org/team", Type: "team"}},
+			},
+		},
+		{
+			name: "pattern with curly braces and pipe character",
+			rule: "foo|{bar}.txt @org/team",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "foo|{bar}.txt"),
+				Owners:  []Owner{{Value: "org/team", Type: "team"}},
+			},
+		},
 
 		// Error cases
 		{
 			name: "empty rule",
 			rule: "",
 			err:  "unexpected end of rule",
-		},
-		{
-			name: "malformed patterns",
-			rule: "file.{txt @user",
-			err:  "unexpected character '{' at position 6",
 		},
 		{
 			name: "patterns with brackets",


### PR DESCRIPTION
This change allows `|` `{` and `}` to be present in rule patterns as literal characters.

fixes #37 