### PR TITLE
Support GitLab syntax

### DIFF
--- a/codeowners.go
+++ b/codeowners.go
@@ -5,27 +5,28 @@
 // the CODEOWNERS file format into rulesets, which may then be used to determine
 // the ownership of files.
 //
-// Usage
+// # Usage
 //
 // To find the owner of a given file, parse a CODEOWNERS file and call Match()
 // on the resulting ruleset.
-//  ruleset, err := codeowners.ParseFile(file)
-//  if err != nil {
-//  	log.Fatal(err)
-//  }
 //
-//  rule, err := ruleset.Match("path/to/file")
-//  if err != nil {
-//  	log.Fatal(err)
-//  }
+//	ruleset, err := codeowners.ParseFile(file)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
 //
-// Command line interface
+//	rule, err := ruleset.Match("path/to/file")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+// # Command line interface
 //
 // A command line interface is also available in the cmd/codeowners package.
 // When run, it will walk the directory tree showing the code owners for each
 // file encountered. The help flag lists available options.
 //
-//  $ codeowners --help
+//	$ codeowners --help
 package codeowners
 
 import (
@@ -122,6 +123,14 @@ type Rule struct {
 	pattern    pattern
 }
 
+type Section struct {
+	Name             string
+	Owners           []Owner
+	Comment          string
+	ApprovalOptional bool
+	ApprovalCount    int
+}
+
 // RawPattern returns the rule's gitignore-style path pattern.
 func (r Rule) RawPattern() string {
 	return r.pattern.pattern
@@ -139,6 +148,10 @@ const (
 	TeamOwner string = "team"
 	// UsernameOwner is the owner type for GitHub usernames.
 	UsernameOwner string = "username"
+	// GroupOwner is the owner type for Gitlab groups.
+	GroupOwner string = "group"
+	// RoleOwner is the owner type for GitLab roles
+	RoleOwner string = "role"
 )
 
 // Owner represents an owner found in a rule.

--- a/example_test.go
+++ b/example_test.go
@@ -100,3 +100,141 @@ func ExampleRuleset_Match() {
 	// src/foo/bar.go true
 	// src/foo.rs false
 }
+
+func ExampleRuleset_Match_section() {
+	f := bytes.NewBufferString(`[SECTION] @the-a-team
+src
+src-b @user-b
+`)
+	ruleset, _ := codeowners.ParseFile(f, codeowners.WithSectionSupport())
+	match, _ := ruleset.Match("src")
+	fmt.Println("src", match != nil)
+	fmt.Println(ruleset[0].Owners[0].String())
+	match, _ = ruleset.Match("src-b")
+	fmt.Println("src-b", match != nil)
+	fmt.Println(ruleset[1].Owners[0].String())
+	// Output:
+	// src true
+	// @the-a-team
+	// src-b true
+	// @user-b
+}
+
+func ExampleRuleset_Match_section_groups() {
+	f := bytes.NewBufferString(`[SECTION] @the/a/group
+src
+src-b @user-b
+src-c @the/c/group
+`)
+	ruleset, _ := codeowners.ParseFile(f, codeowners.WithSectionSupport(), codeowners.WithOwnerMatchers(codeowners.GitLabOwnerMatchers()))
+	match, _ := ruleset.Match("src")
+	fmt.Println("src", match != nil)
+	fmt.Println(ruleset[0].Owners[0].String())
+	match, _ = ruleset.Match("src-b")
+	fmt.Println("src-b", match != nil)
+	fmt.Println(ruleset[1].Owners[0].String())
+	match, _ = ruleset.Match("src-c")
+	fmt.Println("src-c", match != nil)
+	fmt.Println(ruleset[2].Owners[0].String())
+	// Output:
+	// src true
+	// @the/a/group
+	// src-b true
+	// @user-b
+	// src-c true
+	// @the/c/group
+}
+
+func ExampleRuleset_Match_section_groups_multiple() {
+	f := bytes.NewBufferString(`[SECTION] @the/a/group
+* @other
+[SECTION-B] @the/b/group
+b-src
+b-src-b @user-b
+b-src-c @the/c/group
+[SECTION-C]
+`)
+	ruleset, _ := codeowners.ParseFile(f, codeowners.WithSectionSupport(), codeowners.WithOwnerMatchers(codeowners.GitLabOwnerMatchers()))
+	match, _ := ruleset.Match("b-src")
+	fmt.Println("b-src", match != nil)
+	fmt.Println(ruleset[1].Owners[0].String())
+	match, _ = ruleset.Match("b-src-b")
+	fmt.Println("b-src-b", match != nil)
+	fmt.Println(ruleset[2].Owners[0].String())
+	match, _ = ruleset.Match("b-src-c")
+	fmt.Println("b-src-c", match != nil)
+	fmt.Println(ruleset[3].Owners[0].String())
+	// Output:
+	// b-src true
+	// @the/b/group
+	// b-src-b true
+	// @user-b
+	// b-src-c true
+	// @the/c/group
+}
+
+func ExampleRuleset_Match_gitlab_example() {
+	f := bytes.NewBufferString(`
+# Specify a default Code Owner for all files with a wildcard:
+* @default-owner
+
+# Specify multiple Code Owners to a specific file:
+README.md @@technical-writer @doc-team @tech-lead
+
+# Specify a Code Owner to all files with a specific extension:
+*.rb @ruby-owner
+
+# Specify Code Owners with usernames or email addresses:
+LICENSE @legal janedoe@gitlab.com
+
+# Use group names to match groups and nested groups:
+README @group @group/with-nested/subgroup
+
+# Specify a Code Owner to a directory and all its contents:
+/docs/ @all-docs
+/docs/* @root-docs
+/docs/**/*.md @root-docs
+
+^[Optional] @everyone/all @everyone/any
+*.css
+*.html
+
+# Use a section to group related rules:
+[Documentation][2] @@technical-writer
+ee/docs    @docs
+docs       @docs
+
+[IAC] @ops
+.terraform
+charts
+.terraform/important @ops/admins
+
+# Assign a role as a Code Owner:
+/config/ @@maintainer
+`)
+
+	ruleset, err := codeowners.ParseFile(f, codeowners.WithSectionSupport(), codeowners.WithOwnerMatchers(codeowners.GitLabOwnerMatchers()))
+	fmt.Println("err: ", err)
+
+	for _, rule := range ruleset {
+		fmt.Println(rule.RawPattern(), rule.Owners)
+	}
+	// Output:
+	// err:  <nil>
+	// * [@default-owner]
+	// README.md [@technical-writer @doc-team @tech-lead]
+	// *.rb [@ruby-owner]
+	// LICENSE [@legal janedoe@gitlab.com]
+	// README [@group @group/with-nested/subgroup]
+	// /docs/ [@all-docs]
+	// /docs/* [@root-docs]
+	// /docs/**/*.md [@root-docs]
+	// *.css [@everyone/all @everyone/any]
+	// *.html [@everyone/all @everyone/any]
+	// ee/docs [@docs]
+	// docs [@docs]
+	// .terraform [@ops]
+	// charts [@ops]
+	// .terraform/important [@ops/admins]
+	// /config/ [@maintainer]
+}

--- a/gitlab.go
+++ b/gitlab.go
@@ -1,0 +1,33 @@
+package codeowners
+
+import "regexp"
+
+var (
+	gitLabUsernameRegexp = regexp.MustCompile(`\A@(([a-zA-Z0-9\-_]+)([._][a-zA-Z0-9\-_]+)*)\z`)
+	gitLabGroupRegexp    = regexp.MustCompile(`\A@(([a-zA-Z0-9\-_]+)([/][a-zA-Z0-9\-_]+)+)\z`)
+	gitLabRoleNameRegexp = regexp.MustCompile(`\A@@(([a-zA-Z0-9\-_]+)([._][a-zA-Z0-9\-_]+)*)\z`)
+)
+
+func matchCustomOwner(s, t string, rgx *regexp.Regexp) (Owner, error) {
+	match := rgx.FindStringSubmatch(s)
+	if match == nil || len(match) < 2 {
+		return Owner{}, ErrNoMatch
+	}
+
+	return Owner{Value: match[1], Type: t}, nil
+}
+
+func GitLabOwnerMatchers() []OwnerMatcher {
+	return []OwnerMatcher{
+		OwnerMatchFunc(func(s string) (Owner, error) {
+			return matchCustomOwner(s, UsernameOwner, gitLabUsernameRegexp)
+		}),
+		OwnerMatchFunc(func(s string) (Owner, error) {
+			return matchCustomOwner(s, GroupOwner, gitLabGroupRegexp)
+		}),
+		OwnerMatchFunc(func(s string) (Owner, error) {
+			return matchCustomOwner(s, RoleOwner, gitLabRoleNameRegexp)
+		}),
+		OwnerMatchFunc(MatchEmailOwner),
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -7,13 +7,21 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
 type parseOption func(*parseOptions)
 
 type parseOptions struct {
-	ownerMatchers []OwnerMatcher
+	ownerMatchers  []OwnerMatcher
+	sectionSupport bool
+}
+
+func WithSectionSupport() parseOption {
+	return func(opts *parseOptions) {
+		opts.sectionSupport = true
+	}
 }
 
 func WithOwnerMatchers(mm []OwnerMatcher) parseOption {
@@ -103,6 +111,7 @@ func ParseFile(f io.Reader, options ...parseOption) (Ruleset, error) {
 		opt(&opts)
 	}
 
+	sectionOwners := []Owner{}
 	rules := Ruleset{}
 	scanner := bufio.NewScanner(f)
 	lineNo := 0
@@ -115,9 +124,24 @@ func ParseFile(f io.Reader, options ...parseOption) (Ruleset, error) {
 			continue
 		}
 
+		if opts.sectionSupport && isSectionStart(rune(line[0])) {
+			section, err := parseSection(line, opts)
+			if err != nil {
+				return nil, fmt.Errorf("line %d: %w", lineNo, err)
+			}
+
+			sectionOwners = section.Owners
+
+			continue
+		}
+
 		rule, err := parseRule(line, opts)
 		if err != nil {
 			return nil, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+
+		if len(rule.Owners) == 0 {
+			rule.Owners = sectionOwners
 		}
 		rule.LineNumber = lineNo
 		rules = append(rules, rule)
@@ -128,7 +152,149 @@ func ParseFile(f io.Reader, options ...parseOption) (Ruleset, error) {
 const (
 	statePattern = iota + 1
 	stateOwners
+	stateSection
+	stateSectionBrace
+	stateSectionApprovalCount
 )
+
+// parseSection parses a single line of a CODEOWNERS file, returning a Rule struct
+func parseSection(ruleStr string, opts parseOptions) (Section, error) {
+	s := Section{}
+
+	state := stateSection
+	escaped := false
+	buf := bytes.Buffer{}
+	for i, ch := range strings.TrimSpace(ruleStr) {
+		// Comments consume the rest of the line and stop further parsing
+		if ch == '#' {
+			s.Comment = strings.TrimSpace(ruleStr[i+1:])
+			break
+		}
+
+		switch state {
+		case stateSection:
+			switch {
+			case ch == '\\':
+				// Escape the next character (important for whitespace while parsing), but
+				// don't lose the backslash as it's part of the pattern
+				escaped = true
+				buf.WriteRune(ch)
+				continue
+
+			case isSectionStart(ch):
+				if ch == '^' {
+					s.ApprovalOptional = true
+
+					continue
+				}
+
+				state = stateSectionBrace
+				continue
+
+			case isSectionChar(ch):
+				buf.WriteRune(ch)
+
+			case isSectionEnd(ch) || isWhitespace(ch) && !escaped:
+				buf.Reset()
+
+				state = stateOwners
+
+			default:
+				return s, fmt.Errorf("section: unexpected character '%c' at position %d", ch, i+1)
+			}
+
+		case stateSectionBrace:
+			switch {
+			case ch == '\\':
+				// Escape the next character (important for whitespace while parsing), but
+				// don't lose the backslash as it's part of the pattern
+				escaped = true
+				buf.WriteRune(ch)
+				continue
+
+			case isSectionEnd(ch):
+				s.Name = buf.String()
+
+				buf.Reset()
+
+				state = stateOwners
+				continue
+
+			case isSectionChar(ch):
+				// Keep any valid pattern characters and escaped whitespace
+				buf.WriteRune(ch)
+
+			default:
+				return s, fmt.Errorf("section: unexpected character '%c' at position %d", ch, i+1)
+			}
+
+		case stateSectionApprovalCount:
+			switch {
+			case isSectionEnd(ch):
+				approvalCount := buf.String()
+				approvalCountInt, err := strconv.Atoi(approvalCount)
+				if err != nil {
+					return s, fmt.Errorf("section: invalid approval count %w at position %d", err, i+1)
+				}
+				s.ApprovalCount = approvalCountInt
+
+				buf.Reset()
+				state = stateOwners
+
+			default:
+				buf.WriteRune(ch)
+			}
+
+		case stateOwners:
+			switch {
+			case isSectionStart(ch):
+				state = stateSectionApprovalCount
+
+			case isWhitespace(ch):
+				// Whitespace means we've reached the end of the owner or we're just chomping
+				// through whitespace before or after owner declarations
+				if buf.Len() > 0 {
+					ownerStr := buf.String()
+					owner, err := newOwner(ownerStr, opts.ownerMatchers)
+					if err != nil {
+						return s, fmt.Errorf("section: %w at position %d", err, i+1-len(ownerStr))
+					}
+
+					s.Owners = append(s.Owners, owner)
+					buf.Reset()
+				}
+
+			case isOwnersChar(ch):
+				// Write valid owner characters to the buffer
+				buf.WriteRune(ch)
+
+			default:
+				return s, fmt.Errorf("section: unexpected character '%c' at position %d", ch, i+1)
+			}
+		}
+	}
+
+	escaped = false
+
+	// We've finished consuming the line, but we might still have content in the buffer
+	// if the line didn't end with a separator (whitespace)
+	switch state {
+	case stateOwners:
+		// If there's an owner left in the buffer, don't leave it behind
+		if buf.Len() > 0 {
+			ownerStr := buf.String()
+			owner, err := newOwner(ownerStr, opts.ownerMatchers)
+			if err != nil {
+				return s, fmt.Errorf("%s at position %d", err.Error(), len(ruleStr)+1-len(ownerStr))
+			}
+
+			s.Owners = append(s.Owners, owner)
+		}
+
+	}
+
+	return s, nil
+}
 
 // parseRule parses a single line of a CODEOWNERS file, returning a Rule struct
 func parseRule(ruleStr string, opts parseOptions) (Rule, error) {
@@ -270,4 +436,33 @@ func isOwnersChar(ch rune) bool {
 		return true
 	}
 	return isAlphanumeric(ch)
+}
+
+// isSectionChar matches characters that are allowed for section names
+func isSectionChar(ch rune) bool {
+	switch ch {
+	case '.', '@', '/', '_', '%', '+', '-', ' ':
+		return true
+	}
+	return isAlphanumeric(ch)
+}
+
+// isSectionEnd matches characters ends each section block
+// e.g. [Section Name][<approval count>]
+func isSectionEnd(ch rune) bool {
+	switch ch {
+	case ']':
+		return true
+	}
+	return false
+}
+
+// isSectionStart defines characters starting the beginning of a section
+// - `^` starts an optional section
+func isSectionStart(ch rune) bool {
+	switch ch {
+	case '[', '^':
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Taken from @rwese PR https://github.com/hmarr/codeowners/pull/31
Makes less intrusive changes, only allows to programmatically parse GitLab style codeowner files