### PR TITLE
Support for ignoring untracked files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ usage: codeowners <path>...
   -f, --file string     CODEOWNERS file path
   -h, --help            show this help message
   -o, --owner strings   filter results by owner
+  -t, --tracked         only show files tracked by git
   -u, --unowned         only show unowned files (can be combined with -o)
 
 $ ls

--- a/cmd/codeowners/main.go
+++ b/cmd/codeowners/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -17,11 +19,13 @@ func main() {
 		ownerFilters   []string
 		showUnowned    bool
 		codeownersPath string
+		trackedFlag    bool
 		helpFlag       bool
 	)
 	flag.StringSliceVarP(&ownerFilters, "owner", "o", nil, "filter results by owner")
 	flag.BoolVarP(&showUnowned, "unowned", "u", false, "only show unowned files (can be combined with -o)")
 	flag.StringVarP(&codeownersPath, "file", "f", "", "CODEOWNERS file path")
+	flag.BoolVarP(&trackedFlag, "tracked", "t", false, "only show files tracked by git")
 	flag.BoolVarP(&helpFlag, "help", "h", false, "show this help message")
 
 	flag.Usage = func() {
@@ -33,6 +37,33 @@ func main() {
 	if helpFlag {
 		flag.Usage()
 		os.Exit(0)
+	}
+
+	var trackedFiles map[string]bool
+	if trackedFlag {
+		// Ensure the script is run inside a Git repository
+		if _, err := os.Stat(".git"); os.IsNotExist(err) {
+			fmt.Println(os.Stderr, "error: this is not a Git repository.")
+			os.Exit(1)
+		}
+
+		cmd := exec.Command("git", "ls-files")
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		cmd.Stderr = os.Stderr
+
+		if err := cmd.Run(); err != nil {
+			fmt.Println(os.Stderr, "Error running git ls-files:", err)
+			os.Exit(1)
+		}
+
+		trackedFiles = make(map[string]bool)
+		files := strings.Split(out.String(), "\n")
+		for _, file := range files {
+			if file != "" {
+				trackedFiles[file] = true
+			}
+		}
 	}
 
 	ruleset, err := loadCodeowners(codeownersPath)
@@ -57,7 +88,7 @@ func main() {
 	for _, startPath := range paths {
 		// godirwalk only accepts directories, so we need to handle files separately
 		if !isDir(startPath) {
-			if err := printFileOwners(out, ruleset, startPath, ownerFilters, showUnowned); err != nil {
+			if err := printFileOwners(out, ruleset, startPath, ownerFilters, showUnowned, trackedFiles, trackedFlag); err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v", err)
 				os.Exit(1)
 			}
@@ -71,7 +102,7 @@ func main() {
 
 			// Only show code owners for files, not directories
 			if !d.IsDir() {
-				return printFileOwners(out, ruleset, path, ownerFilters, showUnowned)
+				return printFileOwners(out, ruleset, path, ownerFilters, showUnowned, trackedFiles, trackedFlag)
 			}
 			return nil
 		})
@@ -83,7 +114,13 @@ func main() {
 	}
 }
 
-func printFileOwners(out io.Writer, ruleset codeowners.Ruleset, path string, ownerFilters []string, showUnowned bool) error {
+func printFileOwners(out io.Writer, ruleset codeowners.Ruleset, path string, ownerFilters []string, showUnowned bool, trackedFiles map[string]bool, trackedOnly bool) error {
+	if trackedOnly {
+		if _, ok := trackedFiles[path]; !ok {
+			return nil
+		}
+	}
+
 	rule, err := ruleset.Match(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
This creates a command-line argument `-t, --tracked` that only considers files that are currently tracked by git.