### PR TITLE
feat: support Next.js/Nuxt.js-style dynamic route parameters in patterns

### DIFF
--- a/match.go
+++ b/match.go
@@ -157,6 +157,9 @@ func buildPatternRegex(pattern string) (*regexp.Regexp, error) {
 				case '?':
 					// Single-character wildcard
 					re.WriteString(`[^` + sep + `]`)
+				case '[', ']':
+					// Escape square brackets to treat them as literal characters
+					re.WriteString(`\` + string(ch))
 				default:
 					// Regular character
 					re.WriteString(regexp.QuoteMeta(string(ch)))

--- a/parse.go
+++ b/parse.go
@@ -257,7 +257,7 @@ func isAlphanumeric(ch rune) bool {
 // isPatternChar matches characters that are allowed in patterns
 func isPatternChar(ch rune) bool {
 	switch ch {
-	case '*', '?', '.', '/', '@', '_', '+', '-', '\\', '(', ')', '|', '{', '}':
+	case '*', '?', '.', '/', '@', '_', '+', '-', '\\', '(', ')', '|', '{', '}', '[', ']':
 		return true
 	}
 	return isAlphanumeric(ch)

--- a/parse_test.go
+++ b/parse_test.go
@@ -281,11 +281,6 @@ func TestParseRule(t *testing.T) {
 			err:  "unexpected end of rule",
 		},
 		{
-			name: "patterns with brackets",
-			rule: "file.[cC] @user",
-			err:  "unexpected character '[' at position 6",
-		},
-		{
 			name: "malformed owners",
 			rule: "file.txt missing-at-sign",
 			err:  "invalid owner format 'missing-at-sign' at position 10",

--- a/testdata/patterns.json
+++ b/testdata/patterns.json
@@ -305,5 +305,15 @@
          "foo/qux/bar/baz": true,
          "foo/qux/bar/qux": false
       }
+   },
+   {
+      "name": "pattern with square brackets",
+      "pattern": "/apps/[param]/file.ts",
+      "paths": {
+         "apps/[param]/file.ts": true,
+         "apps/other/file.ts": false,
+         "apps/[other]/file.ts": false,
+         "apps/param/file.ts": false
+      }
    }
 ]


### PR DESCRIPTION
This PR adds support for Next.js/Nuxt.js-style dynamic route parameters in CODEOWNERS patterns, addressing [issue #42](https://github.com/hmarr/codeowners/issues/42). 

Modern web frameworks like Next.js and Nuxt.js use square brackets [paramName] in file and directory names to denote dynamic route parameters. This is a fundamental pattern in these frameworks' file-based routing systems. 
Examples:
```
/pages/users/[userId].js              # Dynamic user page
/pages/[category]/[productId].js      # Dynamic product in category
/api/[supplierId]/performance/*.ts    # API endpoints with supplier context
```
Currently, CODEOWNERS rejects such patterns with an error:
```
unexpected character '[' at position X
```