### PR TITLE
Allow any escaped character in pattern

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -164,8 +164,8 @@ func parseRule(ruleStr string, opts parseOptions) (Rule, error) {
 				buf.Reset()
 				state = stateOwners
 
-			case isPatternChar(ch) || (isWhitespace(ch) && escaped):
-				// Keep any valid pattern characters and escaped whitespace
+			case isPatternChar(ch) || escaped:
+				// Keep any valid pattern characters and escaped characters
 				buf.WriteRune(ch)
 
 			default:

--- a/parse_test.go
+++ b/parse_test.go
@@ -273,6 +273,14 @@ func TestParseRule(t *testing.T) {
 				Owners:  []Owner{{Value: "org/team", Type: "team"}},
 			},
 		},
+		{
+			name: "patterns with escaped brackets",
+			rule: "nameWith\\[brackets\\] @org/team",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "nameWith\\[brackets\\]"),
+				Owners:  []Owner{{Value: "org/team", Type: "team"}},
+			},
+		},
 
 		// Error cases
 		{


### PR DESCRIPTION
Per GitHub [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax), CODEOWNERS follows mostly gitignore syntax. gitignore [documents](https://git-scm.com/docs/gitignore#_pattern_format):

> A backslash ("\\") can be used to escape any character.

This rule is not explicitly disabled by GitHub, so should be respected.

This PR adds support for any escaped character in the CODEOWNERS patterns.

