### PR TITLE
Allow tilde in patterns

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -257,7 +257,7 @@ func isAlphanumeric(ch rune) bool {
 // isPatternChar matches characters that are allowed in patterns
 func isPatternChar(ch rune) bool {
 	switch ch {
-	case '*', '?', '.', '/', '@', '_', '+', '-', '\\', '(', ')', '|', '{', '}':
+	case '*', '?', '.', '/', '@', '_', '+', '-', '\\', '(', ')', '|', '{', '}', '~':
 		return true
 	}
 	return isAlphanumeric(ch)

--- a/parse_test.go
+++ b/parse_test.go
@@ -273,6 +273,14 @@ func TestParseRule(t *testing.T) {
 				Owners:  []Owner{{Value: "org/team", Type: "team"}},
 			},
 		},
+		{
+			name: "pattern with tilde '~'",
+			rule: "foobar~.txt @org/team",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "foobar~.txt"),
+				Owners:  []Owner{{Value: "org/team", Type: "team"}},
+			},
+		},
 
 		// Error cases
 		{


### PR DESCRIPTION
This pull request makes a minor update to pattern parsing by allowing the tilde character `~` in patterns. It also adds a corresponding test to ensure this new behavior is covered.

- **Pattern Parsing Update:**
  - Allowed the tilde character `~` as a valid pattern character in the `isPatternChar` function in `parse.go`.

- **Testing:**
  - Added a test case in `parse_test.go` to verify that patterns containing `~` are parsed correctly.
  
Reference: 
Same as https://github.com/hmarr/codeowners/issues/37.
Also, the tilde character is accepted by GitHub CODEOWNERS format.