### PR TITLE
Allow colons in CODEOWNERS patterns

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -257,7 +257,7 @@ func isAlphanumeric(ch rune) bool {
 // isPatternChar matches characters that are allowed in patterns
 func isPatternChar(ch rune) bool {
 	switch ch {
-	case '*', '?', '.', '/', '@', '_', '+', '-', '\\', '(', ')', '|', '{', '}':
+	case '*', '?', '.', '/', '@', '_', '+', '-', ':', '\\', '(', ')', '|', '{', '}':
 		return true
 	}
 	return isAlphanumeric(ch)

--- a/parse_test.go
+++ b/parse_test.go
@@ -172,6 +172,14 @@ func TestParseRule(t *testing.T) {
 			},
 		},
 		{
+			name: "pattern with colon",
+			rule: "services/foo:bar/**/* @org/team",
+			expected: Rule{
+				pattern: mustBuildPattern(t, "services/foo:bar/**/*"),
+				Owners:  []Owner{{Value: "org/team", Type: "team"}},
+			},
+		},
+		{
 			name: "pattern with space",
 			rule: "foo\\ bar @user",
 			expected: Rule{

--- a/testdata/patterns.json
+++ b/testdata/patterns.json
@@ -305,5 +305,13 @@
          "foo/qux/bar/baz": true,
          "foo/qux/bar/qux": false
       }
+   },
+   {
+      "name": "pattern with colon",
+      "pattern": "services/foo:bar/**/*",
+      "paths": {
+         "services/foo:bar/baz.json": true,
+         "services/foo-bar/baz.json": false
+      }
    }
 ]


### PR DESCRIPTION
Hey Harry ol' buddy ol' pal! 💛 

## Summary

- allow `:` as a literal CODEOWNERS pattern character
- add focused parser and matcher regressions for colon-containing patterns

## Problem

`isPatternChar` omitted colons, causing otherwise valid CODEOWNERS patterns to fail parsing with an unexpected-character error. The matcher already treats colons literally, so adding `:` to the parser whitelist is sufficient.

## Why

GitHub's CODEOWNERS validator API allows directory/file paths containing `:` characters, but this library does not.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./cmd/codeowners`